### PR TITLE
Fix case when the GRUB configuration file uses simple quotes

### DIFF
--- a/system76driver/actions.py
+++ b/system76driver/actions.py
@@ -37,11 +37,11 @@ from .model import determine_model_new
 
 
 log = logging.getLogger()
-CMDLINE_RE = re.compile('^GRUB_CMDLINE_LINUX_DEFAULT="(.*)"$')
+CMDLINE_RE = re.compile('^GRUB_CMDLINE_LINUX_DEFAULT=["\'](.*)["\']\s*$')
 CMDLINE_TEMPLATE = 'GRUB_CMDLINE_LINUX_DEFAULT="{}"'
 
 CMDLINE_CHECK_DEFAULT_RE = re.compile('^GRUB_CMDLINE_LINUX_DEFAULT')
-CMDLINE_ADD_DEFAULT_RE = re.compile('^GRUB_CMDLINE_LINUX="(.*)"$')
+CMDLINE_ADD_DEFAULT_RE = re.compile('^GRUB_CMDLINE_LINUX=["\'](.*)["\']\s*$')
 
 LSPCI_RE = re.compile(r'^(.+) \[(.+)\]$')
 


### PR DESCRIPTION
When launching the app (./startlud.sh), I had an error:
```
2025-11-29 18:22:24,387 INFO ** Process start at monotonic time 524625.469002425 2025-11-29 18:22:24,387 INFO system76driver.version: '20.04.99' 2025-11-29 18:22:24,388 INFO OS: 'Garuda Linux'
2025-11-29 18:22:24,388 INFO kernel: '6.12.58-1-lts' 2025-11-29 18:22:24,388 INFO model: 'kevlar1.amd'
Traceback (most recent call last):
File "/media/DONNEES/binaires/Tongfang/system76driver/gtk.py", line 94, in prepare_action_runner self.action_runner = ActionRunner(self.product['drivers']) ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^
File "/media/DONNEES/binaires/Tongfang/system76driver/actions.py", line 242, in init if action.isneeded:
^^^^^^^^^^^^^^^
File "/media/DONNEES/binaires/Tongfang/system76driver/actions.py", line 168, in isneeded self._isneeded = self.get_isneeded()
~~~~~~~~~~~~~~~~~^^
File "/media/DONNEES/binaires/Tongfang/system76driver/actions.py", line 431, in get_isneeded current = self.get_current_cmdline()
File "/media/DONNEES/binaires/Tongfang/system76driver/actions.py", line 386, in get_current_cmdline raise Exception('Could not parse GRUB_CMDLINE_LINUX_DEFAULT') Exception: Could not parse GRUB_CMDLINE_LINUX_DEFAULT
```

The current commit fixes this.